### PR TITLE
Bring updates from main repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, NVIDIA Corporation
+Copyright (c) 2017-2019, NVIDIA Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Jitify provides/takes care of the following things:
  * Dealing with kernel name mangling
  * Reflecting kernel template parameters into strings
  * Compiling specifically for the current device's compute capability
- * Support for CUDA versions 7.0, 7.5, 8.0, 9.0
+ * Support for CUDA versions 7.0, 7.5, 8.0, 9.x, 10.x
  * Convenient parallel_for function and lambda support
 
 Things you can do with Jitify and NVRTC:

--- a/example_headers/constant_header.cuh
+++ b/example_headers/constant_header.cuh
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of NVIDIA CORPORATION nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace {
+
+  namespace b { __constant__ int a[3]; }
+
+}
+
+__global__ void constant_test2(int *x) {
+  for (int i=0; i<3; i++) x[i] = (b::a[i]);
+}

--- a/example_headers/constant_header.cuh
+++ b/example_headers/constant_header.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/example_headers/my_header1.cuh
+++ b/example_headers/my_header1.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/example_headers/my_header2.cuh
+++ b/example_headers/my_header2.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/example_headers/my_header3.cuh
+++ b/example_headers/my_header3.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1285,9 +1285,6 @@ static const char* jitsafe_header_type_traits = R"(
     template<class> struct is_function : false_type { };
     template<class Ret, class... Args> struct is_function<Ret(Args...)> : true_type {}; //regular
     template<class Ret, class... Args> struct is_function<Ret(Args......)> : true_type {}; // variadic
-    #if __cplusplus >= 201402L
-    template< class T > inline constexpr bool is_function_v = is_function<T>::value;
-    #endif
 
     template<class> struct result_of;
     template<class F, typename... Args>
@@ -1704,24 +1701,22 @@ static const char* jitsafe_header_algorithm = R"(
     #pragma once
     #if __cplusplus >= 201103L
     namespace __jitify_algorithm_ns {
+
     #if __cplusplus == 201103L
-    template<class T> const T& max(const T& a, const T& b)
-    {
-      return (b > a) ? b : a;
-    }
-    template<class T> const T& min(const T& a, const T& b)
-    {
-      return (b < a) ? b : a;
-    }
+    #define JITIFY_CXX14_CONSTEXPR
     #else
-    template<class T> constexpr const T& max(const T& a, const T& b)
+    #define JITIFY_CXX14_CONSTEXPR constexpr
+    #endif
+
+    template<class T> JITIFY_CXX14_CONSTEXPR const T& max(const T& a, const T& b)
     {
       return (b > a) ? b : a;
     }
-    template<class T> constexpr const T& min(const T& a, const T& b)
+    template<class T> JITIFY_CXX14_CONSTEXPR const T& min(const T& a, const T& b)
     {
       return (b < a) ? b : a;
     }
+
     #endif
     } // namespace __jitify_algorithm_ns
     namespace std { using namespace __jitify_algorithm_ns; }

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -966,7 +966,6 @@ class CUDAKernel {
   inline void create_constant() {
     size_t pos = 0;
     while (pos < _ptx.size()) {
-      // find any constants
       pos = _ptx.find(".const .align", pos);
       if (pos == std::string::npos) break;
       size_t end = _ptx.find(";", pos);

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1833,7 +1833,7 @@ inline void detect_and_add_cuda_arch(std::vector<std::string>& options) {
                     (cc_major == 7 && cc_minor == 2) ); // Xavier
   if (!is_tegra) {
     // ensure that future CUDA versions just work (even if suboptimal)
-    const int cuda_major = std::min(7, CUDA_VERSION / 1000);
+    const int cuda_major = std::min(10, CUDA_VERSION / 1000);
     switch (cuda_major) {
     case 10: cc = std::min(cc, 75); break; // Turing
     case 9: cc = std::min(cc, 70); break;  // Volta

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -134,6 +134,7 @@
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
 #define JITIFY_PRINT_PTX 1
+#define JITIFY_PRINT_LINKER_LOG 1
 #define JITIFY_PRINT_LAUNCH 1
 #endif
 
@@ -900,6 +901,11 @@ class CUDAKernel {
   std::string _ptx;
   std::map<std::string, std::string> _constant;
   std::vector<CUjit_option> _opts;
+  std::vector<void*> _optvals;
+#ifdef JITIFY_PRINT_LINKER_LOG
+  char info_log[8192];
+  unsigned int logSize = 8192;
+#endif
 
   inline void cuda_safe_call(CUresult res) const {
     if (res != CUDA_SUCCESS) {
@@ -909,14 +915,16 @@ class CUDAKernel {
     }
   }
   inline void create_module(std::vector<std::string> link_files,
-                            std::vector<std::string> link_paths,
-                            void** optvals = 0) {
+                            std::vector<std::string> link_paths) {
+#ifndef JITIFY_PRINT_LINKER_LOG
+    // WAR since linker log does not seem to be constructed using a single call to cuModuleLoadDataEx
     if (link_files.empty()) {
       cuda_safe_call(cuModuleLoadDataEx(&_module, _ptx.c_str(), _opts.size(),
-                                        _opts.data(), optvals));
-    } else {
-      cuda_safe_call(
-          cuLinkCreate(_opts.size(), _opts.data(), optvals, &_link_state));
+                                        _opts.data(), _optvals.data()));
+    } else
+#endif
+    {
+      cuda_safe_call(cuLinkCreate(_opts.size(), _opts.data(), _optvals.data(), &_link_state));
       cuda_safe_call(cuLinkAddData(_link_state, CU_JIT_INPUT_PTX,
                                    (void*)_ptx.c_str(), _ptx.size(),
                                    "jitified_source.ptx", 0, 0, 0));
@@ -949,6 +957,13 @@ class CUDAKernel {
       cuda_safe_call(cuLinkComplete(_link_state, &cubin, &cubin_size));
       cuda_safe_call(cuModuleLoadData(&_module, cubin));
     }
+#ifdef JITIFY_PRINT_LINKER_LOG
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << "--- Linker for " << reflection::detail::demangle(_func_name.c_str()) << " ---" << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << info_log << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+#endif
     cuda_safe_call(cuModuleGetFunction(&_kernel, _module, _func_name.c_str()));
   }
   inline void destroy_module() {
@@ -1002,8 +1017,17 @@ class CUDAKernel {
         _kernel(0),
         _func_name(func_name),
         _ptx(ptx),
-        _opts(opts, opts + nopts) {
-    this->create_module(link_files, link_paths, optvals);
+        _opts(opts, opts + nopts),
+        _optvals(optvals, optvals + nopts) {
+#ifdef JITIFY_PRINT_LINKER_LOG
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER);
+    _optvals.push_back((void *) info_log);
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+    _optvals.push_back((void *) (long)logSize);
+    _opts.push_back(CU_JIT_LOG_VERBOSE);
+    _optvals.push_back((void *)1);
+#endif
+    this->create_module(link_files, link_paths);
     this->create_constant();
   }
   inline CUDAKernel& set(const char* func_name, const char* ptx,
@@ -1017,7 +1041,15 @@ class CUDAKernel {
     _link_files = link_files;
     _link_paths = link_paths;
     _opts.assign(opts, opts + nopts);
-    this->create_module(link_files, link_paths, optvals);
+#ifdef JITIFY_PRINT_LINKER_LOG
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER);
+    _optvals.push_back((void *) info_log);
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+    _optvals.push_back((void *) (long)logSize);
+    _opts.push_back(CU_JIT_LOG_VERBOSE);
+    _optvals.push_back((void *)1);
+#endif
+    this->create_module(link_files, link_paths);
     this->create_constant();
     return *this;
   }
@@ -2532,11 +2564,9 @@ inline void KernelInstantiation_impl::build_kernel() {
 
 #if JITIFY_PRINT_PTX
   std::cout << "---------------------------------------" << std::endl;
-  std::cout << mangled_instantiation << std::endl;
+  std::cout << "--- PTX for " << mangled_instantiation << " in " << program.name() << " ---" << std::endl;
   std::cout << "---------------------------------------" << std::endl;
-  std::cout << "--- PTX for " << program.name() << " ---" << std::endl;
-  std::cout << "---------------------------------------" << std::endl;
-  std::cout << ptx << std::endl;
+  std::cout << ptx;
   std::cout << "---------------------------------------" << std::endl;
 #endif
 

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -35,6 +35,7 @@
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
 #define JITIFY_PRINT_PTX 1
+#define JITIFY_PRINT_LINKER_LOG 1
 #define JITIFY_PRINT_LAUNCH 1
 #include "jitify.hpp"
 

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -210,7 +210,7 @@ bool test_constant() {
   dim3 grid(1);
   dim3 block(1);
   {  // test __constant__ look up in kernel string using diffrent namespaces
-    const char* const_program = R"(
+    const char* const_program = R"(const_program
     #pragma once
 
     __constant__ int a;

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/stringify.cpp
+++ b/stringify.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
   std::string line;
   // Note: This puts "filename\n" at the beginning of the string, which is
   //         what jitify expects.
-  ostream << "const char* " << varname << " = "
+  ostream << "const char* const " << varname << " = "
           << "\"" << filename << "\\n\"" << std::endl;
   while (std::getline(istream, line)) {
     ostream << "\"" << sanitize_string_literal(line) << "\\n\"" << std::endl;

--- a/stringify.cpp
+++ b/stringify.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
This is being done because a bug we face in cuDF (https://github.com/rapidsai/cudf/issues/2712) is fixed in upstream and we want the fix.

I tested using the latest changes from NVIDIA/Jitify in cuDF and the gtests that used to fail with Turing on CUDA 9.2 are now passing.