### PR TITLE
hotfix for jitify2 support in cudf, replaces `/` with `_` in jit cach…

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -5758,7 +5758,7 @@ class ProgramCache {
         mem_cache_(max_in_mem),
         file_cache_(std::move(file_cache_path),
                     max_files ? max_files : max_in_mem,
-                    /* prefix = */ preprog_.name() + ".", file_suffix),
+                    /* prefix = */ std::regex_replace(preprog_.name(), std::regex("/"), "_") + ".", file_suffix),
         hash_(hash),
         equal_(equal),
         to_filename_(to_filename) {}


### PR DESCRIPTION
Hacky fix to allow using preprocessed kernels that live in sub directories. Replaces `/` with `_` so LRUFileCache only needs to create a file, not a directory.

Needed to make file caching work in https://github.com/rapidsai/cudf/pull/7372