### PR TITLE
remove unfinished string_view support for c++17 builds.

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -53,9 +53,9 @@
 #include <unordered_map>
 #include <vector>
 
-#if __cplusplus >= 201703L
-#include <string_view>
-#endif
+// #if __cplusplus >= 201703L
+// #include <string_view>
+// #endif
 
 #else  // not JITIFY_SERIALIZATION_ONLY
 
@@ -176,13 +176,13 @@ namespace jitify2 {
 using StringVec = std::vector<std::string>;
 using StringMap = std::unordered_map<std::string, std::string>;
 
-#if __cplusplus >= 201703L
-using StringRef = std::string_view;
-using StringSlice = std::string_view;
-#else
+// #if __cplusplus >= 201703L
+// using StringRef = std::string_view;
+// using StringSlice = std::string_view;
+// #else
 using StringRef = const std::string&;
 using StringSlice = std::string;
-#endif
+// #endif
 
 namespace serialization {
 
@@ -200,9 +200,9 @@ struct imemstream : virtual membuf, std::istream {
   imemstream(const char* data, size_t size)
       : membuf(data, size), std::istream(static_cast<std::streambuf*>(this)) {}
   imemstream(const std::string& str) : imemstream(str.data(), str.size()) {}
-#if __cplusplus >= 201703L
-  imemstream(std::string_view sv) : imemstream(sv.data(), sv.size()) {}
-#endif
+// #if __cplusplus >= 201703L
+//   imemstream(std::string_view sv) : imemstream(sv.data(), sv.size()) {}
+// #endif
 };
 
 // This should be incremented whenever the serialization format changes in any
@@ -679,10 +679,10 @@ inline std::string reflect(const Instance<T>& value) {
 inline std::string reflect(const std::string& s) { return s; }
 /*! Use an existing code string as-is. */
 inline const char* reflect(const char* s) { return s; }
-#if __cplusplus >= 201703L
-/*! Use an existing code string as-is. */
-inline std::string_view reflect(std::string_view s) { return s; }
-#endif
+// #if __cplusplus >= 201703L
+// /*! Use an existing code string as-is. */
+// inline std::string_view reflect(std::string_view s) { return s; }
+// #endif
 
 /*! Create a Type object representing a value's type.
  *  \code{.cpp}type_of(3.14f) -> Type<float>()\endcode


### PR DESCRIPTION
This addresses the following c++17 build error in the `cudf-0.20` branch.

```
In file included from include/jit_preprocessed_files/binaryop/jit/kernel.cu.jit.hpp:3:0,
                 from ../src/binaryop/binaryop.cpp:23:
_deps/jitify-src/jitify2.hpp: In function 'bool jitify2::detail::copy_compiler_option_for_driver_ptxas(const StringVec&, jitify2::StringVec*, bool, jitify2::StringRef, jitify2::StringRef, jitify2::StringRef)':
_deps/jitify-src/jitify2.hpp:2689:34: error: no matching function for call to 'std::vector<std::__cxx11::basic_string<char> >::push_back(jitify2::StringSlice&)'
     linker_options->push_back(key);
```