### PR TITLE
fix climits dups fix

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -45,7 +45,7 @@
 // unnecessary dependencies.
 #ifdef JITIFY_SERIALIZATION_ONLY
 
-#include <cuda/std/climits>
+#include <climits>
 #include <iostream>
 #include <sstream>
 #include <streambuf>
@@ -73,7 +73,7 @@
 #endif
 
 #include <algorithm>
-#include <cuda/std/climits>
+#include <climits>
 #include <cstring>
 #include <fstream>
 #include <functional>

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -45,7 +45,7 @@
 // unnecessary dependencies.
 #ifdef JITIFY_SERIALIZATION_ONLY
 
-#include <climits>
+#include <cuda/std/climits>
 #include <iostream>
 #include <sstream>
 #include <streambuf>
@@ -73,7 +73,7 @@
 #endif
 
 #include <algorithm>
-#include <climits>
+#include <cuda/std/climits>
 #include <cstring>
 #include <fstream>
 #include <functional>
@@ -3172,7 +3172,7 @@ DEFINE_MATH_UNARY_FUNC_WRAPPER(nearbyint)
 )");
 
 // TODO: offsetof
-JITIFY_DEFINE_C_AND_CXX_HEADERS_EX(stddef, "#include <climits>", R"(
+JITIFY_DEFINE_C_AND_CXX_HEADERS_EX(stddef, "#include <cuda/std/climits>", R"(
 #if __cplusplus >= 201103L
 typedef decltype(nullptr) nullptr_t;
 #if defined(_MSC_VER)
@@ -3200,7 +3200,7 @@ using ::ptrdiff_t;
 )");
 
 JITIFY_DEFINE_C_AND_CXX_HEADERS(stdint, R"(
-#include <climits>
+#include <cuda/std/climits>
 #define INT8_MIN SCHAR_MIN
 #define INT16_MIN SHRT_MIN
 #define INT32_MIN INT_MIN
@@ -3461,7 +3461,7 @@ struct iterator_traits<T const*> {
 static const char* const jitsafe_header_limits = R"(
 #pragma once
 #include <cfloat>
-#include <climits>
+#include <cuda/std/climits>
 #include <cstdint>
 // TODO: epsilon(), infinity(), etc
 namespace std {


### PR DESCRIPTION
pre-processing jitify2 kernels outputs lots of warnings because both `climits` and `cuda/std/climits` are included in jit-compiled source code. This is because jitify prefers `climits` whereas cudf prefers `cuda/std/climits`. I believe these warnings didn't present in jitify1 because we were ignoring much of it's output. Now, they've become annoying. To get rid of them, we need to use one or the other. Since cudf uses `cuda/std/climits`, I've updated jitify to include the that for jit-compiled sources.
```
cuda/std/climits(29): warning: incompatible redefinition of macro "ULONG_MAX"
climits(34): here
cuda/std/climits(34): warning: incompatible redefinition of macro "LLONG_MIN"
climits(37): here
cuda/std/climits(35): warning: incompatible redefinition of macro "LLONG_MAX"
climits(36): here
cuda/std/climits(36): warning: incompatible redefinition of macro "ULLONG_MAX"
climits(38): here
```

This is a hacky fix, and we should examine how to let jitify2 work well with any code's choice of includes.